### PR TITLE
Fix memory safety tests by adding GITHUB_TOKEN for protoc downloads

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -217,4 +217,5 @@ jobs:
         cargo +nightly miri test --lib -- --test-threads=1
       env:
         MIRIFLAGS: -Zmiri-disable-isolation
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -158,25 +158,27 @@ jobs:
 
     - name: Build with TLS features
       run: cargo build --release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run TLS configuration validation tests
       run: |
         echo "🔐 Running TLS configuration validation..."
-        cargo test tls_config_validation --verbose
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo test tls_config_validation --verbose
 
     - name: Run certificate validation tests
       run: |
         echo "🔐 Running certificate validation tests..."
-        cargo test --test tls_integration_tests test_tls_config_validation --verbose
-        cargo test --test tls_integration_tests test_invalid_certificate --verbose
-        cargo test --test tls_integration_tests test_certificate_loading --verbose
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo test --test tls_integration_tests test_tls_config_validation --verbose
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo test --test tls_integration_tests test_invalid_certificate --verbose
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo test --test tls_integration_tests test_certificate_loading --verbose
 
     - name: Validate TLS cipher suites and protocols
       run: |
         echo "🔐 Validating TLS security configuration..."
         # Build a temporary TLS server for validation
-        cargo build --release
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo build --release
         # Note: This would ideally use a security scanning tool
         # For now, we validate through our test suite
-        cargo test --test tls_integration_tests security --verbose || true
+        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" cargo test --test tls_integration_tests security --verbose || true
 


### PR DESCRIPTION
## Problem

The memory safety tests were failing with exit code 101 due to GitHub API rate limiting during the build process. The error was:

```
API rate limit exceeded for 172.184.209.164. (But here's the good news: 
Authenticated requests get a higher rate limit. Check out the documentation 
for more details.)
```

This happened because `protoc-prebuilt` was trying to download the Protocol Buffers compiler from GitHub releases without authentication, hitting the 60 requests/hour rate limit for unauthenticated requests.

## Solution

Added `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` environment variable to:

- **Memory safety tests** in `.github/workflows/integration.yml`
- **Security workflow TLS jobs** in `.github/workflows/security.yml` for consistency

## Benefits

- ✅ Provides authenticated GitHub API access (5,000 requests/hour vs 60 unauthenticated)
- ✅ Prevents future rate limiting issues in CI 
- ✅ No manual setup required - `GITHUB_TOKEN` is automatically provided by GitHub Actions
- ✅ Fixes the root cause of memory safety test failures

## Testing

- [x] Verified YAML syntax is valid
- [x] Confirmed `GITHUB_TOKEN` is automatically available (no secrets setup needed)
- [x] Memory safety tests ran successfully locally with Miri

The original failure wasn't actually a memory safety issue - it was purely a build infrastructure problem now resolved.

Fixes #memory-safety-test-failures